### PR TITLE
Update for 1.0.0 release

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,7 +3,7 @@ RUN apk update &&\
     apk upgrade &&\
     apk add ca-certificates &&\
     rm -rf /var/cache/apk/*
-ADD https://github.com/containous/traefik/releases/download/v1.0.0/traefik_linux-arm /traefik
+ADD https://github.com/containous/traefik/releases/download/v1.0.0/traefik_linux-arm64 /traefik
 RUN chmod +x /traefik
 EXPOSE 80 8080
 ENTRYPOINT ["/traefik"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,9 +1,0 @@
-FROM hypriot/rpi-alpine-scratch
-RUN apk update &&\
-    apk upgrade &&\
-    apk add ca-certificates &&\
-    rm -rf /var/cache/apk/*
-ADD https://github.com/containous/traefik/releases/download/v1.0.0/traefik_linux-arm64 /traefik
-RUN chmod +x /traefik
-EXPOSE 80 8080
-ENTRYPOINT ["/traefik"]


### PR DESCRIPTION
Update for [Traefik 1.0.0](https://blog.containo.us/traefik-1-0-0-reblochon-is-out-e6fca002284d#.onwsobvzl) :-)
