### PR TITLE
Add Dockerfile-devel to follow unstable version of Traefik

### DIFF
--- a/Dockerfile-devel
+++ b/Dockerfile-devel
@@ -4,7 +4,7 @@ RUN apk update &&\
     apk upgrade &&\
     apk add ca-certificates &&\
     rm -rf /var/cache/apk/*
-ADD https://github.com/containous/traefik/releases/download/v1.0.3/traefik_linux-arm /traefik
+ADD https://github.com/containous/traefik/releases/download/v1.1.0-rc3/traefik_linux-arm /traefik
 RUN chmod +x /traefik
 EXPOSE 80 8080
 ENTRYPOINT ["/traefik"]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
-# rpi-traefik
+# docker-arm-traefik
 
 Build an ARM docker container for [Traefik](https://traefik.io/) based on [Alpine](http://alpinelinux.org/)
 
-## Run it
+## Release notes
 
-For eg:
+* 20161029 : 1.0.3 release + devel file to follow 1.1-rc versions
+* 20160520 : Initial release - with Traefik [v1.0.0-beta.732](https://github.com/containous/traefik/releases/tag/v1.0.0-beta.732)
+
+## Build it
+
+Clone the repository and then:
 
 ```
-docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.toml hypriot-rpi-traefik
+docker build -t <you>/<image_name> .
+```
+
+## Run it
+
+```
+docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.toml nsteinmetz/traefik-arm
 ``` 
 
-## Blog post
-
-* [Microservices Bliss with Docker and Traefik](http://blog.hypriot.com/post/microservices-bliss-with-docker-and-traefik/)
-
-## Documentation
-
 Read the [Traefik documentation](https://docs.traefik.io/) for more details.
-

--- a/README.md
+++ b/README.md
@@ -1,24 +1,19 @@
-# docker-arm-traefik
+# rpi-traefik
 
 Build an ARM docker container for [Traefik](https://traefik.io/) based on [Alpine](http://alpinelinux.org/)
 
-## Release notes
-
-* 20161029 : 1.0.3 release + devel file to follow 1.1-rc versions
-* 20160520 : Initial release - with Traefik [v1.0.0-beta.732](https://github.com/containous/traefik/releases/tag/v1.0.0-beta.732)
-
-## Build it
-
-Clone the repository and then:
-
-```
-docker build -t <you>/<image_name> .
-```
-
 ## Run it
 
+For eg:
+
 ```
-docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.toml nsteinmetz/traefik-arm
+docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.toml hypriot-rpi-traefik
 ``` 
+
+## Blog post
+
+* [Microservices Bliss with Docker and Traefik](http://blog.hypriot.com/post/microservices-bliss-with-docker-and-traefik/)
+
+## Documentation
 
 Read the [Traefik documentation](https://docs.traefik.io/) for more details.


### PR DESCRIPTION
- Add Dockerfile-devel dockerfile to follow unstable version (1.1rc3 as of now)
- For impatient, images are also here, use tags to get the right version (latest == stable (1.0.3), for unstable, please specify tag) : https://hub.docker.com/r/nsteinmetz/traefik-arm/tags/
