### PR TITLE
Move to Alpine 3.4 instead of 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-#FROM hypriot/rpi-alpine-scratch
-FROM nsteinmetz/alpine-arm:3.4
+FROM hypriot/rpi-alpine-scratch:v3.4
 MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
 RUN apk update &&\
     apk upgrade &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM hypriot/rpi-alpine-scratch
+#FROM hypriot/rpi-alpine-scratch
+FROM nsteinmetz/alpine-arm:3.4
 MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
 RUN apk update &&\
     apk upgrade &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hypriot/rpi-alpine-scratch:v3.4
+FROM armhf/alpine:3.4
 MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
 RUN apk update &&\
     apk upgrade &&\

--- a/Dockerfile-devel
+++ b/Dockerfile-devel
@@ -1,5 +1,4 @@
-#FROM hypriot/rpi-alpine-scratch
-FROM nsteinmetz/alpine-arm:3.4
+FROM hypriot/rpi-alpine-scratch:v3.4
 MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
 RUN apk update &&\
     apk upgrade &&\

--- a/Dockerfile-devel
+++ b/Dockerfile-devel
@@ -1,4 +1,5 @@
-FROM hypriot/rpi-alpine-scratch
+#FROM hypriot/rpi-alpine-scratch
+FROM nsteinmetz/alpine-arm:3.4
 MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
 RUN apk update &&\
     apk upgrade &&\

--- a/Dockerfile-devel
+++ b/Dockerfile-devel
@@ -1,4 +1,4 @@
-FROM hypriot/rpi-alpine-scratch:v3.4
+FROM armhf/alpine:3.4
 MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
 RUN apk update &&\
     apk upgrade &&\

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Build an ARM docker container for [Traefik](https://traefik.io/) based on [Alpin
 For eg:
 
 ```
-docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.toml hypriot-rpi-traefik
+docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.toml hypriot/rpi-traefik
 ``` 
 
 ## Blog post


### PR DESCRIPTION
Just saw that tags for rpi-alpine-scratch contains v3.4 - latest is sticked with 3.2 - it may need an update.
