### PR TITLE
Bump to 1.1.0/camembert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update &&\
     apk upgrade &&\
     apk add ca-certificates &&\
     rm -rf /var/cache/apk/*
-ADD https://github.com/containous/traefik/releases/download/v1.0.3/traefik_linux-arm /traefik
+ADD https://github.com/containous/traefik/releases/download/v1.1.0/traefik_linux-arm /traefik
 RUN chmod +x /traefik
 EXPOSE 80 8080
 ENTRYPOINT ["/traefik"]


### PR DESCRIPTION
* Traefik 1.1.0/Camembert was just released today - https://blog.containo.us/introducing-distributed-cheese-traefik-1-1-camembert-is-out-fb19e05a48c8