### PR TITLE
Try to build without cross-build tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM hypriot/rpi-alpine-qemu:3.4
 MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
-RUN [ "cross-build-start" ]
 RUN apk update &&\
     apk upgrade &&\
     apk add ca-certificates &&\
     rm -rf /var/cache/apk/*
 ADD https://github.com/containous/traefik/releases/download/v1.1.0/traefik_linux-arm /traefik
 RUN chmod +x /traefik
-RUN [ "cross-build-end" ]
 EXPOSE 80 8080
 ENTRYPOINT ["/traefik"]


### PR DESCRIPTION
Try to remove the two RUN commands from the Dockerfile, but build on Travis shows same error as Docker for Mac:

```
Sending build context to Docker daemon 162.8 kB
Step 1 : FROM hypriot/rpi-alpine-qemu:3.4
 ---> d19b625da8b3
Step 2 : MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
 ---> Using cache
 ---> b93babd7ba4e
Step 3 : RUN apk update &&    apk upgrade &&    apk add ca-certificates &&    rm -rf /var/cache/apk/*
 ---> Running in 1d4bca048aa6
-0: applet not found
The command '/bin/sh -c apk update &&    apk upgrade &&    apk add ca-certificates &&    rm -rf /var/cache/apk/*' returned a non-zero code: 127
```
