### PR TITLE
Remove cross-builder-start step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,15 @@ script:
 # prepare qemu
 - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 # build image
-- docker build -t hypriot/rpi-traefik .
+- docker build -t hypriot/rpi-traefik:build .
 # test image
-- docker run hypriot/rpi-traefik version
+- docker run hypriot/rpi-traefik:build version
 # push image
 - >
   if [ "$TRAVIS_BRANCH" == "master" ]; then
     docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
-    docker tag hypriot/rpi-traefik hypriot/rpi-traefik:v1.1.0
+    docker tag hypriot/rpi-traefik:build hypriot/rpi-traefik:v1.1.0
     docker push hypriot/rpi-traefik:v1.1.0
-    docker push hypriot/rpi-traefik
+    docker tag hypriot/rpi-traefik:build hypriot/rpi-traefik:latest
+    docker push hypriot/rpi-traefik:latest
   fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM hypriot/rpi-alpine-qemu:3.4
+FROM hypriot/rpi-alpine:3.4
 MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
-RUN [ "cross-build-start" ]
 RUN apk update &&\
     apk upgrade &&\
     apk add ca-certificates &&\
     rm -rf /var/cache/apk/*
 ADD https://github.com/containous/traefik/releases/download/v1.1.0/traefik_linux-arm /traefik
 RUN chmod +x /traefik
-RUN [ "cross-build-end" ]
 EXPOSE 80 8080
 ENTRYPOINT ["/traefik"]


### PR DESCRIPTION
Use `hypriot/rpi-alpine:3.4` base image and remove the cross-builder steps.
