### PR TITLE
bump 1.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM hypriot/rpi-alpine:3.4
+FROM armhf/alpine:3.4
 MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
 RUN apk update &&\
     apk upgrade &&\
     apk add ca-certificates &&\
     rm -rf /var/cache/apk/*
-ADD https://github.com/containous/traefik/releases/download/v1.1.1/traefik_linux-arm /traefik
+ADD https://github.com/containous/traefik/releases/download/v1.1.2/traefik_linux-arm /traefik
 RUN chmod +x /traefik
 EXPOSE 80 8080
 ENTRYPOINT ["/traefik"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hypriot/rpi-alpine
+FROM hypriot/rpi-alpine:3.4
 RUN apk update &&\
     apk upgrade &&\
     apk add ca-certificates &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM armhf/alpine:3.4
-MAINTAINER Nicolas Steinmetz <public+docker@steinmetz.fr>
+FROM hypriot/rpi-alpine
 RUN apk update &&\
     apk upgrade &&\
     apk add ca-certificates &&\
     rm -rf /var/cache/apk/*
 ADD https://github.com/containous/traefik/releases/download/v1.1.2/traefik_linux-arm /traefik
 RUN chmod +x /traefik
-EXPOSE 80 8080
+EXPOSE 80 8080 443
 ENTRYPOINT ["/traefik"]


### PR DESCRIPTION
The only question is should we use ``armhf/alpine`` or ``hypriot/rpi-alpine:3.4`` ; in a previous PR, we agreed on using ``armhf/alpine`` instead of ``hypriot/rpi-alpine-scrach`` if I remember well due to low maintenance of this image.

What's the status of ``hypriot/rpi-alpine`` ?